### PR TITLE
feat: highlight currently-available cities on the network map

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -94,8 +94,9 @@ function refreshColors() {
   COLORS.accentFill = v('--accent-fill', 'rgba(230, 0, 126, 0.06)');
   COLORS.mapStyle = v('--map-style', "'carto-positron'").replace(/['"]/g, '');
   COLORS.hub = COLORS.accent;
-  COLORS.dest = COLORS.slate;
+  COLORS.dest = COLORS.accent;
   COLORS.other = v('--map-other', '#1f2937');
+  COLORS.partner = v('--map-partner', '#00a35c');
 }
 
 function baseLayout() {
@@ -985,7 +986,7 @@ function renderMap() {
     hoverinfo: 'skip',
     showlegend: false,
   }];
-  const orderedColors = [COLORS.other, COLORS.dest, COLORS.hub];
+  const orderedColors = [...new Set([COLORS.other, COLORS.partner, COLORS.dest, COLORS.hub])];
   const showLabel = !!(hub || destination);
   for (const color of orderedColors) {
     const group = grouped.get(color);
@@ -1121,12 +1122,14 @@ function collectMapPoints(hub, destination, totalDays) {
       const [o, d] = DATA.routes[rid];
       if (o === hi) dests.add(d);
     }
+    const current = currentPartners(hi, true);
     pushAirport(out, hub, COLORS.hub, anchorHover(hub, hi, dests, totalDays, true), 12);
     for (const di of dests) {
       const name = DATA.airports[di];
       const outRid = getRouteIdx(hi, di);
       const retRid = getRouteIdx(di, hi);
-      pushAirport(out, name, COLORS.other, routeHover(name, outRid, name, retRid, hub, totalDays, lastDateIdx));
+      const color = current.has(di) ? COLORS.partner : COLORS.other;
+      pushAirport(out, name, color, routeHover(name, outRid, name, retRid, hub, totalDays, lastDateIdx));
     }
   } else if (destination && !hub) {
     const di = DATA.airportIdx[destination];
@@ -1135,12 +1138,14 @@ function collectMapPoints(hub, destination, totalDays) {
       const [o, d] = DATA.routes[rid];
       if (d === di) origins.add(o);
     }
+    const current = currentPartners(di, false);
     pushAirport(out, destination, COLORS.dest, anchorHover(destination, di, origins, totalDays, false), 13);
     for (const oi of origins) {
       const name = DATA.airports[oi];
       const outRid = getRouteIdx(oi, di);
       const retRid = getRouteIdx(di, oi);
-      pushAirport(out, name, COLORS.other, routeHover(name, outRid, destination, retRid, name, totalDays, lastDateIdx));
+      const color = current.has(oi) ? COLORS.partner : COLORS.other;
+      pushAirport(out, name, color, routeHover(name, outRid, destination, retRid, name, totalDays, lastDateIdx));
     }
   } else {
     const stats = computeAllAirportStats();
@@ -1157,6 +1162,17 @@ function collectMapPoints(hub, destination, totalDays) {
     }
   }
   return out;
+}
+
+function currentPartners(ai, isHub) {
+  const iso = DATA.dates[DATA.dates.length - 1];
+  const partners = new Set();
+  for (const rid of DATA.availability[iso]) {
+    const [o, d] = DATA.routes[rid];
+    if (isHub && o === ai) partners.add(d);
+    else if (!isHub && d === ai) partners.add(o);
+  }
+  return partners;
 }
 
 function pushAirport(out, name, color, hover, size = 9) {

--- a/docs/style.css
+++ b/docs/style.css
@@ -16,6 +16,7 @@
   --accent-fill: rgba(230, 0, 126, 0.06);
   --slate: #404040;
   --map-other: #1f2937;
+  --map-partner: #00a35c;
   --map-style: 'carto-positron';
   --shadow-stuck: 0 4px 16px rgba(10, 10, 10, 0.04);
   --shadow-pop: 0 12px 32px rgba(10, 10, 10, 0.08), 0 2px 6px rgba(10, 10, 10, 0.04);
@@ -40,6 +41,7 @@
   --accent-fill: rgba(255, 40, 145, 0.10);
   --slate: #d4d4d4;
   --map-other: #d4d4d4;
+  --map-partner: #1fd881;
   --map-style: 'carto-darkmatter';
   --shadow-stuck: 0 4px 16px rgba(0, 0, 0, 0.5);
   --shadow-pop: 0 12px 32px rgba(0, 0, 0, 0.55), 0 2px 6px rgba(0, 0, 0, 0.35);


### PR DESCRIPTION
Two map fixes on the network chart in `docs/`.

**Arrival anchor was the wrong color.** Picking a departure airport turned its dot pink, but picking an arrival airport appeared to do nothing. `COLORS.dest` was `--slate` (`#404040`), visually indistinguishable from the `--map-other` (`#1f2937`) dots surrounding it. It now uses the pink accent, same as the hub anchor. Safe because `renderMap()` hides the card entirely when both hub and destination are set (`main.js:970`), so the two anchor colors never appear together. `orderedColors` is deduped to avoid emitting the same trace twice now that the values are equal.

**Currently-available cities are now green.** New `--map-partner` custom property (`#00a35c` light, `#1fd881` dark). New helper `currentPartners(ai, isHub)` reads `DATA.availability[latest date]` — the same source the "Today" panel uses at `main.js:387` — so the green set on the map matches the city list exactly. Partners that appear only in historical data keep the neutral `--map-other` color.

## Test plan

- [x] `node --check docs/main.js` passes
- [x] Departure selection: anchor renders pink, current destinations render green, historical-only destinations stay neutral
- [x] Arrival selection: anchor renders pink (the reported bug), current origins render green
- [x] No selection: overview map unchanged, all dots neutral
- [x] Dark theme spot-check of `--map-partner: #1fd881` on `carto-darkmatter`
- [ ] Confirm the green set matches the "Today" panel city list one-for-one